### PR TITLE
fix to create a release apk

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -162,6 +162,7 @@ dependencies {
     implementation(Dependencies.CRASHLYTICS)
     implementation(Dependencies.PLAY_CORE)
     implementation(Dependencies.DAGGER)
+    implementation(Dependencies.COIL)
 
     debugImplementation(DebugDependencies.LEAKCANARY)
 

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -19,3 +19,6 @@
 # If you keep the line number information, uncomment this to
 # hide the original source file name.
 #-renamesourcefileattribute SourceFile
+
+# TODO: This is just a workaround, obfuscation temporarily disabled.  
+-keep class com.vmadalin.** { *; }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -4,7 +4,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     package="com.vmadalin.android">
 
-    <dist:module dist:instant="true" />
+    <dist:module dist:instant="false" />
 
     <uses-permission android:name="android.permission.INTERNET" />
 

--- a/features/characters_favorites/src/main/AndroidManifest.xml
+++ b/features/characters_favorites/src/main/AndroidManifest.xml
@@ -4,12 +4,12 @@
     package="com.vmadalin.dynamicfeatures.charactersfavorites">
 
     <dist:module
-        dist:instant="true"
+        dist:instant="false"
         dist:title="@string/feature_characters_favorite">
         <dist:delivery>
             <dist:install-time />
         </dist:delivery>
-        <dist:fusing dist:include="false" />
+        <dist:fusing dist:include="true" />
     </dist:module>
 
     <application

--- a/features/characters_list/src/main/AndroidManifest.xml
+++ b/features/characters_list/src/main/AndroidManifest.xml
@@ -4,12 +4,12 @@
     package="com.vmadalin.dynamicfeatures.characterslist">
 
     <dist:module
-        dist:instant="true"
+        dist:instant="false"
         dist:title="@string/feature_characters_list">
         <dist:delivery>
             <dist:install-time />
         </dist:delivery>
-        <dist:fusing dist:include="false" />
+        <dist:fusing dist:include="true" />
     </dist:module>
 
     <application

--- a/features/home/src/main/AndroidManifest.xml
+++ b/features/home/src/main/AndroidManifest.xml
@@ -4,12 +4,12 @@
     package="com.vmadalin.dynamicfeatures.home">
 
     <dist:module
-        dist:instant="true"
+        dist:instant="false"
         dist:title="@string/feature_home">
         <dist:delivery>
             <dist:install-time />
         </dist:delivery>
-        <dist:fusing dist:include="false" />
+        <dist:fusing dist:include="true" />
     </dist:module>
 
     <application


### PR DESCRIPTION
## Description

A fix to allow assign and run successfully production apk, obfuscation need to be optimized

Fixes #10 

## Type of change

-   added coil as a dependency  on app module
-   dynamic features are declared not instant so
-   added proguard rule on app module

## How Has This Been Tested

-   [ ]  to generate an universal apk run this gradle task: **packageProdReleaseUniversalApk** (I don't know why but in my case the traditional step by step release project from the IDE generate an apk that does not include all the features)


## Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my own code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] My changes generate no new warnings
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] New and existing unit tests pass locally with my changes
-   [ ] Any dependent changes have been merged and published in downstream modules
