### PR TITLE
Update build.gradle.kts

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -43,7 +43,7 @@ object PluginsVersions {
     const val KTLINT = "0.39.0"
     const val SPOTLESS = "5.6.1"
     const val DETEKT = "1.14.1"
-    const val GRAPH_GENERATOR = "0.6.0-SNAPSHOT"
+    const val GRAPH_GENERATOR = "0.6.0"
 }
 
 dependencies {


### PR DESCRIPTION
## Description

This will fix a build error. 0.6.0-SNAPSHOT doesn't exist anymore, it's been replaced by 0.7.0-SNAPSHOT.
More : https://github.com/vanniktech/gradle-dependency-graph-generator-plugin

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

-   [ ] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

-   [ ] With a build

### Test Configuration

-   Firmware version :
-   Hardware :
-   Toolchain :
-   SDK :

## Checklist

-   [ ] My code follows the style guidelines of this project
-   [ ] I have performed a self-review of my own code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have made corresponding changes to the documentation
-   [ ] My changes generate no new warnings
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] New and existing unit tests pass locally with my changes
-   [ ] Any dependent changes have been merged and published in downstream modules
